### PR TITLE
sort input files (boo#1041090)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC      = gcc
 CFLAGS  = -c -g -O2 -Wall
 LDFLAGS =
 
-SRC     = $(wildcard *.c)
+SRC     = $(sort $(wildcard *.c))
 OBJ     = $(SRC:.c=.o)
 
 GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)


### PR DESCRIPTION
when building packages
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.