### PR TITLE
work also with older gpg versions

### DIFF
--- a/testmediacheck
+++ b/testmediacheck
@@ -434,7 +434,11 @@ sub gpg_init
     close $p;
   }
 
-  system "gpg --homedir=$gpg_dir --import $gpg_dir/test.pub >/dev/null 2>&1";
+  # older gpg versions use the secret key file here
+  my $key = "$gpg_dir/test.sec";
+  $key = "$gpg_dir/test.pub" unless -f $key;
+
+  system "gpg --homedir=$gpg_dir --import $key >/dev/null 2>&1";
 
   return $gpg_dir;
 }


### PR DESCRIPTION
### Problem

Older GPG versions had a secret key file containing both the secret and public keys. You had to use this file for some operations.