### PR TITLE
work better with broken media (bsc#1169420)

### DIFF
--- a/mediacheck.c
+++ b/mediacheck.c
@@ -708,7 +708,7 @@ void get_info(mediacheck_t *media)
   // if we didn't get the image size via stat() above, try other ways
   if(!media->full_blocks) {
     media->full_blocks = media->part_start + media->part_blocks;
-    if(!media->full_blocks) media->full_blocks = media->iso_blocks;
+    if(media->iso_blocks > media->full_blocks) media->full_blocks = media->iso_blocks;
   }
 
   close(fd);


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1169420

If partition table info is incorrect, checkmedia might calculate the image size wrongly.

## Solution

If partition size and iso size disagree, choose the bigger one.