### PR TITLE
do not select EFI System Partition for digest calculation (bsc#1211953)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ archive: changelog
 	xz -f package/$(PREFIX).tar
 
 clean:
-	rm -rf *.o *.so *.so.* *.1 *.html package checkmedia digestdemo *~ tests/*.{img,check,tag}
+	rm -rf *.o *.so *.so.* *.1 *.html package checkmedia digestdemo *~ */*~ tests/*.{img,check,tag}

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ DIGEST_OBJ  = $(DIGEST_SRC:.c=.o)
 
 LIBDIR = /usr/lib$(shell ldd /bin/sh | grep -q /lib64/ && echo 64)
 
+.PHONY: all doc clean install test archive
+
 all: checkmedia digestdemo
 
 checkmedia: checkmedia.c $(LIB_FILENAME)
@@ -57,6 +59,14 @@ install: checkmedia
 	ln -snf $(LIB_SONAME) $(DESTDIR)$(LIBDIR)/$(LIB_NAME).so
 	install -m 644 -D mediacheck.h $(DESTDIR)/usr/include/mediacheck.h
 
+%.1: %_man.adoc
+	asciidoctor -b manpage -a version=$(VERSION) -a soversion=${MAJOR_VERSION} $<
+
+README.html: README.adoc
+	asciidoctor -b html -a version=$(VERSION) -a soversion=${MAJOR_VERSION} $<
+
+doc: tagmedia.1 checkmedia.1 README.html
+
 archive: changelog
 	@if [ ! -d .git ] ; then echo no git repo ; false ; fi
 	mkdir -p package
@@ -65,4 +75,4 @@ archive: changelog
 	xz -f package/$(PREFIX).tar
 
 clean:
-	rm -rf *.o *.so *.so.* package checkmedia digestdemo *~ tests/*.{img,check,tag}
+	rm -rf *.o *.so *.so.* *.1 *.html package checkmedia digestdemo *~ tests/*.{img,check,tag}

--- a/checkmedia_man.adoc
+++ b/checkmedia_man.adoc
@@ -1,0 +1,77 @@
+= checkmedia(1)
+:doctype: manpage
+:manmanual: User Commands
+:mansource: checkmedia {version}
+
+== Name
+
+checkmedia - check installation or Live media.
+
+== Synopsis
+
+*checkmedia* [_OPTIONS_] _IMAGE_
+
+
+== Description
+
+Installation/Live media carry some meta data stored in a reserved area in the ISO9660 file system.
+
+*checkmedia* can use these data to verify the media integrity.
+
+_IMAGE_ is an installation or Live medium; either ISO image or disk image.
+
+Meta data come in two flavors: SUSE (SLE, openSUSE) style and Red Hat (RHEL, Fedora, CentOS, AlmaLinux, Rocky, ...) style.
+Both variants are supported.
+
+For a detailed technical view, see file:///usr/share/doc/packages/libmediacheck{soversion}/README.html
+
+=== Options
+
+*--key-file* _FILE_::
+Use public key in _FILE_ for signature verification.
+
+*--version*::
+Show *checkmedia* version.
+
+*-v*, *--verbose*::
+Show more detailed info (repeat for more).
+
+*-h*, *--help*::
+Write this help text.
+
+== Notes
+
+If the meta data block contains several digests - for example, a digest over the entire ISO and, in case there is a partition table, also
+a digest over a partition - all digests are checked.
+
+If a signature block is present, the signature is verified.
+
+The default setting is to use keys installed in */usr/lib/rpm/gnupg/keys*. Pass an individual key file using the *--key-file* option
+if some other key was used to sign (for example, your own key).
+
+To verify an image built in the Open Build Service, extract the public project key with *osc signkey*.
+
+== Examples
+
+----
+# check foo.iso
+checkmedia foo.iso
+
+# check foo.iso, verify signature using your personal key ring
+checkmedia --key-file ~/.gnupg/pubring.gpg foo.iso
+
+# check foo.iso, built in the OBS in Foo:Bar:Project using the OBS project key
+osc signkey Foo:Bar:Project | sed -e 's/>-/>\n-/' | checkmedia --key-file - foo.iso
+----
+
+== See Also
+
+*checkisomd5*(1), *gpg*(1), *implantisomd5*(1), *osc*(1), *tagmedia*(1).
+
+== Links
+
+- detailed doc: https://github.com/openSUSE/checkmedia/blob/master/README.adoc
+- libmediacheck doc: https://github.com/openSUSE/checkmedia/blob/master/mediacheck.md
+- checkmedia web site: https://github.com/openSUSE/checkmedia
+- Open Build Service: https://openbuildservice.org
+- openSUSE Build Service: https://build.opensuse.org

--- a/obs/checkmedia.spec
+++ b/obs/checkmedia.spec
@@ -1,0 +1,96 @@
+#
+# spec file for package checkmedia
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:           checkmedia
+Summary:        Check installation or Live media
+License:        GPL-3.0-or-later
+Group:          System/Management
+Version:        0.0
+Release:        0
+URL:            https://github.com/openSUSE/checkmedia
+Source:         %{name}-%{version}.tar.xz
+BuildRequires:  gpg
+BuildRequires:  xz
+BuildRequires:  rubygem(asciidoctor)
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+
+%description
+The program checks installation or Live media for errors.
+
+%define libversion %(echo %version | cut -d. -f1)
+
+%package -n     libmediacheck%{libversion}
+Summary:        Library for checking installation or Live media
+Group:          System/Libraries
+Requires:       gpg
+
+%description -n libmediacheck%{libversion}
+Library for checking installation or Live media. Used by checkmedia and linuxrc.
+
+%package -n     libmediacheck-devel
+Summary:        Library for checking installation or Live media
+Group:          Development/Libraries/C and C++
+Requires:       libmediacheck%{libversion} = %version
+
+%description -n libmediacheck-devel
+Library for checking installation or Live media. Used by checkmedia and linuxrc.
+
+%prep
+%setup
+
+%build
+make %{?_smp_mflags}
+
+%check
+make test
+
+%install
+install -d -m 755 %{buildroot}/usr/bin
+%make_install
+make doc
+install -D -m 644 checkmedia.1 %{buildroot}%{_mandir}/man1/checkmedia.1
+install -D -m 644 tagmedia.1 %{buildroot}%{_mandir}/man1/tagmedia.1
+
+%post -n libmediacheck%{libversion} -p /sbin/ldconfig
+
+%postun -n libmediacheck%{libversion} -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root)
+/usr/bin/checkmedia
+/usr/bin/tagmedia
+%doc %{_mandir}/man1/checkmedia.*
+%doc %{_mandir}/man1/tagmedia.*
+
+%files -n libmediacheck%{libversion}
+%defattr(-,root,root)
+%{_libdir}/*.so.*
+%doc README.*
+%doc mediacheck.md
+%if 0%{?suse_version} >= 1500
+%license COPYING
+%else
+%doc COPYING
+%endif
+
+%files -n libmediacheck-devel
+%defattr(-,root,root)
+%{_libdir}/*.so
+%{_includedir}/mediacheck.h
+
+%changelog

--- a/tagmedia
+++ b/tagmedia
@@ -394,6 +394,8 @@ sub get_image_type
 
   # Scan mbr for last primary partition.
   #
+  # Ignore EFI system partition.
+  #
   # Set $image->{part_start}, $image->{part_blocks} (in 0.5 kiB units).
   #
   if(substr($image->{blob}, MBR_MAGIC_START, 2) eq "\x55\xaa") {
@@ -408,6 +410,7 @@ sub get_image_type
 
       if(
         $type &&
+        $type != 0xef &&
         !($boot & 0x7f) &&
         $size &&
         $start + $size > $image->{part_start} + $image->{part_blocks}

--- a/tagmedia
+++ b/tagmedia
@@ -490,7 +490,7 @@ sub get_skip_value
 
     set_tag $tags, { key => "SKIPSECTORS", value => $skip_value } if defined $skip_value;;
 
-    $skip_value = SKIP_DEFAULT if !defined $skip_value;
+    $skip_value = SKIP_DEFAULT if !defined $skip_value && $opt_style eq 'rh';
 
     $image->{skip_blocks} = $skip_value << 2;
     $image->{iso_blocks} -= $image->{skip_blocks};

--- a/tagmedia_man.adoc
+++ b/tagmedia_man.adoc
@@ -1,0 +1,163 @@
+= tagmedia(1)
+:doctype: manpage
+:manmanual: User Commands
+:mansource: tagmedia {version}
+
+== Name
+
+tagmedia - add/remove tags to installation or Live media.
+
+== Synopsis
+
+*tagmedia* [_OPTIONS_] _IMAGE_
+
+
+== Description
+
+Installation/Live media carry some meta data stored in a reserved area in the ISO9660 file system.
+
+*tagmedia* can display and modify these data.
+
+The data are in text form, structured as key=value pairs. Most notably they include a digest (checksum) over the
+entire medium that can be used for verification with *checkmedia*(1).
+
+The meta data block can optionally be signed to verify its authenticity.
+
+_IMAGE_ is an installation or Live medium; either ISO image or disk image.
+
+Meta data come in two flavors: SUSE (SLE, openSUSE) style and Red Hat (RHEL, Fedora, CentOS, AlmaLinux, Rocky, ...) style.
+Both variants are supported.
+
+For a detailed technical view, see file:///usr/share/doc/packages/libmediacheck{soversion}/README.html
+
+If a digest was added, the media can be verified with *checkmedia*(1) (both Red Hat and SUSE style) or *checkisomd5*(1) (Red Hat style only).
+
+=== General options
+
+*--style* _STYLE_::
+Data format. _STYLE_ can be either 'rh' or 'suse' (default: auto-detected).
+
+*--version*::
+Show *tagmedia* version.
+
+*-v*, *--verbose*::
+Show more detailed info (repeat for more).
+
+*--help*::
+Write this help text.
+
+=== Tag related options
+
+*--show*::
+Show current tags (default if no option is given).
+
+*--add-tag* _FOO_=_BAR_::
+Add tag _FOO_ with value _BAR_.
+
+*--remove-tag* _FOO_::
+Remove tag _FOO_.
+
+*--clean*::
+Remove all tags.
+
+*--export-tags* _FILE_::
+Export raw tag data to _FILE_.
+
+=== Digest related options
+
+*--digest* _DIGEST_::
+Add digest _DIGEST_ (suse style: md5, sha1, sha224, sha256, sha384, sha512, rh style: md5).
+
+*--fragments* _N_::
+Split image into _N_ fragments with individual digests (suse style default: 0, rh style default: 20)
+
+*--pad* _N_::
+Ignore _N_ 2 kiB blocks of padding at image end (suse style).
+
+*--skip* _N_::
+Ignore _N_ 2 kiB blocks at image end (rh style, default: 15).
+
+*--check*::
+Tell installer to run media check at startup (suse style).
+
+*--supported*::
+Set supported flag (rh style).
+
+=== Signature related options
+
+*--create-signature* _KEYID_::
+Sign meta data in _IMAGE_ with gpg key _KEYID_. The public part of _KEYID_ is exported to the file _IMAGE_.key.
+
+*--import-signature* _FILE_::
+Import signature from _FILE_.
+
+*--export-signature* _FILE_::
+Export signature to _FILE_.
+
+=== Legacy options
+
+*--md5*, *--md5sum*::
+Equivalent to *--digest md5*.
+
+== Digest notes
+
+The digest is calculated over the entire image, leaving out the meta data block and, if one exists, the signature block. Padding blocks
+are also not taken into account.
+
+For SUSE style media a separate digest over the last partition is also added, if a partition table exists.
+If this happens to be an EFI System Partition, the last but one partition is used.
+
+For Red Hat style media, the media is additionally split into parts (fragments) with separate checksums for each part to help localize
+where any mismatch occurs.
+
+For a description of how exactly the digests are calculated, see the detailed doc link below.
+
+== Signing notes
+
+You can add a signature of the meta data block. It can then be used to ensure the authenticity of the meta data, notably the stored digest.
+
+The signature is stored in a special 2 kiB block. The block can be anywhere in the image, usually as part of the file system.
+The block is identified by a magic id (see detailed doc link below).
+
+Note that usually this block has to be included during image creation. It does not have to be visible in the file system.
+
+*tagmedia* scans the image for a block with this magic id when calculating a digest and stores a reference to it in the 'signature' tag if one is found.
+
+As an exception, if no such block had been identified, *tagmedia* will try to create one in the padding area, if a padding area exists.
+
+If you do not want *tagmedia* to run gpg directly, it is also possible to create the signature independently of *tagmedia* using *--export-tags* to store the raw meta data in a file, then sign it
+and import the signature using the *--import-signature* option.
+
+== Open Build Service
+
+If a signature block is present the OBS will automatically sign images with the project key.
+
+You can get the public part of the project key needed for verification with *osc signkey*.
+
+== Examples
+
+----
+# display current meta data
+tagmedia foo.iso
+
+# create digest
+tagmedia --digest sha256 foo.iso
+
+# create digest, adding a rh-style fragment digest for early error detection
+tagmedia --digest sha256 --fragments 20 foo.iso
+
+# create signature, using gpg key id foo-key
+tagmedia --create-signature foo-key foo.iso
+----
+
+== See Also
+
+*checkisomd5*(1), *checkmedia*(1), *gpg*(1), *implantisomd5*(1), *osc*(1).
+
+== Links
+
+- detailed doc: https://github.com/openSUSE/checkmedia/blob/master/README.adoc
+- libmediacheck doc: https://github.com/openSUSE/checkmedia/blob/master/mediacheck.md
+- checkmedia web site: https://github.com/openSUSE/checkmedia
+- Open Build Service: https://openbuildservice.org
+- openSUSE Build Service: https://build.opensuse.org


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1211953

When a partition table is present, `tagmedia` wrongly picks the ESP (EFI System Partition) for digest calculation in some situations.

Technically, `tagmedia` uses the last partition. Unfortunately, the partition order is swapped when using `xorriso` compared to `mkisofs`.

## Solution

Explicitly ignore the ESP.

## Bonus

1. Take the opportunity and add man pages.
2. Add OBS spec file to git repo.
3. Correct minor issue with tagmedia assuming a non-zero value for SKIPSECTORS for SUSE media in some corner case.