### PR TITLE
set LC_MESSAGES to C when running gpg (bsc#1248168)

### DIFF
--- a/checkmedia.c
+++ b/checkmedia.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
     return 1;
   }
 
-  if(media->app_id) printf("        app: %s\n", media->app_id);
+  if(*media->app_id) printf("        app: %s\n", media->app_id);
   if(media->iso_blocks) {
     printf(
       "   iso size: %u%s kiB\n",

--- a/mediacheck.c
+++ b/mediacheck.c
@@ -1022,7 +1022,7 @@ void verify_signature(mediacheck_t *media)
   free(buf);
 
   asprintf(&buf,
-    "/usr/bin/gpg --batch --homedir %s --no-default-keyring --ignore-time-conflict --ignore-valid-from "
+    "LC_MESSAGES=C.UTF-8 /usr/bin/gpg --batch --homedir %s --no-default-keyring --ignore-time-conflict --ignore-valid-from "
     "--keyring %s/sign.gpg --import %s >%s/gpg_keys.log 2>&1",
     tmp_dir,
     tmp_dir,
@@ -1048,7 +1048,7 @@ void verify_signature(mediacheck_t *media)
 
   if(!cmd_err) {
     asprintf(&buf,
-      "/usr/bin/gpg --batch --homedir %s --no-default-keyring --ignore-time-conflict --ignore-valid-from "
+      "LC_MESSAGES=C.UTF-8 /usr/bin/gpg --batch --homedir %s --no-default-keyring --ignore-time-conflict --ignore-valid-from "
       "--keyring %s/sign.gpg --verify %s/foo.asc %s/foo >%s/gpg_sign.log 2>&1",
       tmp_dir, tmp_dir, tmp_dir, tmp_dir, tmp_dir
     );


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1248168

For signature checks, gpg output is parsed.

Set `LC_MESSAGES` to `C.UTF-8` when running gpg to avoid translations.