### PR TITLE
fine-tune build requirements

### DIFF
--- a/obs/checkmedia.spec
+++ b/obs/checkmedia.spec
@@ -27,7 +27,7 @@ Source:         %{name}-%{version}.tar.xz
 BuildRequires:  xz
 BuildRequires:  (gpg2 or gnupg2)
 # the next line is for Fedora Rawhide; we want at least ssl 3 but resolve the ambiguity to ssl 4
-BuildRequires:  (pkgconfig(libcrypto) >= 3 without openssl3-devel)
+BuildRequires:  (pkgconfig(libcrypto) >= 3.1 without openssl3-devel)
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description


### PR DESCRIPTION
## Task

- fix dependencies: `EVP_MD_CTX_dup()` was added in openssl 3.1.